### PR TITLE
Add HTTP Basic authentication to JettyHttpClient

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
@@ -53,6 +53,9 @@ public class HttpClientConfig
     private String trustStorePath = System.getProperty(JAVAX_NET_SSL_TRUST_STORE);
     private String trustStorePassword = System.getProperty(JAVAX_NET_SSL_TRUST_STORE_PASSWORD);
     private boolean authenticationEnabled;
+    private boolean hostnameVerificationEnabled = true;
+    private String basicAuthUser;
+    private String basicAuthPass;
     private String kerberosPrincipal;
     private String kerberosRemoteServiceName;
 
@@ -248,6 +251,42 @@ public class HttpClientConfig
     public HttpClientConfig setAuthenticationEnabled(boolean enabled)
     {
         this.authenticationEnabled = enabled;
+        return this;
+    }
+
+    public boolean getHostnameVerificationEnabled() { return hostnameVerificationEnabled; }
+
+    @Config("http-client.hostname-verification.enabled")
+    @ConfigDescription("Enable hostname verification of ssl certs")
+    public HttpClientConfig setHostnameVerificationEnabled(boolean enabled)
+    {
+        this.hostnameVerificationEnabled = enabled;
+        return this;
+    }
+
+    public String getBasicAuthUser()
+    {
+        return basicAuthUser;
+    }
+
+    @Config("http-client.authentication.basic-auth.user")
+    @ConfigDescription("Set http auth username")
+    public HttpClientConfig setBasicAuthUser(String user)
+    {
+        this.basicAuthUser = user;
+        return this;
+    }
+
+    public String getBasicAuthPass()
+    {
+        return basicAuthPass;
+    }
+
+    @Config("http-client.authentication.basic-auth.pass")
+    @ConfigDescription("Set http auth password")
+    public HttpClientConfig setBasicAuthPass(String pass)
+    {
+        this.basicAuthPass = pass;
         return this;
     }
 

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -29,10 +29,12 @@ import io.airlift.units.Duration;
 import org.eclipse.jetty.client.DuplexConnectionPool;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpClientTransport;
+import org.eclipse.jetty.client.HttpConversation;
 import org.eclipse.jetty.client.HttpExchange;
 import org.eclipse.jetty.client.HttpRequest;
 import org.eclipse.jetty.client.PoolingHttpDestination;
 import org.eclipse.jetty.client.Socks4Proxy;
+import org.eclipse.jetty.client.api.Authentication;
 import org.eclipse.jetty.client.api.AuthenticationStore;
 import org.eclipse.jetty.client.api.ContentProvider;
 import org.eclipse.jetty.client.api.Destination;
@@ -41,6 +43,7 @@ import org.eclipse.jetty.client.api.Response.Listener;
 import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.client.http.HttpConnectionOverHTTP;
+import org.eclipse.jetty.client.util.BasicAuthentication;
 import org.eclipse.jetty.client.util.BytesContentProvider;
 import org.eclipse.jetty.client.util.InputStreamResponseListener;
 import org.eclipse.jetty.client.util.PathContentProvider;
@@ -92,6 +95,7 @@ import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.eclipse.jetty.client.api.Authentication.ANY_REALM;
 
 public class JettyHttpClient
         implements io.airlift.http.client.HttpClient
@@ -165,7 +169,12 @@ public class JettyHttpClient
         creationLocation.fillInStackTrace();
 
         SslContextFactory sslContextFactory = new SslContextFactory();
-        sslContextFactory.setEndpointIdentificationAlgorithm("HTTPS");
+        if (config.getHostnameVerificationEnabled()) {
+            sslContextFactory.setEndpointIdentificationAlgorithm("HTTPS");
+        }
+        else {
+            sslContextFactory.setEndpointIdentificationAlgorithm(null);
+        }
         if (config.getKeyStorePath() != null) {
             sslContextFactory.setKeyStorePath(config.getKeyStorePath());
             sslContextFactory.setKeyStorePassword(config.getKeyStorePassword());
@@ -185,13 +194,50 @@ public class JettyHttpClient
             transport = new HttpClientTransportOverHTTP(CLIENT_TRANSPORT_SELECTORS);
         }
 
-        if (authenticationEnabled) {
+        if (authenticationEnabled && config.getBasicAuthUser() == null && config.getBasicAuthPass() == null) {
             requireNonNull(kerberosConfig.getConfig(), "kerberos config path is null");
             requireNonNull(config.getKerberosRemoteServiceName(), "kerberos remote service name is null");
             httpClient = new SpnegoHttpClient(kerberosConfig, config, transport, sslContextFactory);
         }
         else {
-            httpClient = new HttpClient(transport, sslContextFactory);
+            httpClient = new HttpClient(transport, sslContextFactory) {
+                protected HttpRequest newHttpRequest(HttpConversation conversation, URI uri)
+                {
+                    HttpRequest request = super.newHttpRequest(conversation, uri);
+
+                    // Hack to preemptively authorize requests because we don't appear to retry
+                    Authentication auth = getAuthenticationStore().findAuthentication("Basic", uri, ANY_REALM);
+                    if (auth != null) {
+                        Authentication.HeaderInfo headerInfo = new Authentication.HeaderInfo(
+                                null, null, null, HttpHeader.AUTHORIZATION
+                        );
+                        Authentication.Result authResult = auth.authenticate(request, null, headerInfo, null);
+                        authResult.apply(request);
+                    }
+                    return request;
+                }
+            };
+
+            if (authenticationEnabled) {
+                Authentication auth =  new BasicAuthentication(null, ANY_REALM,
+                        config.getBasicAuthUser(), config.getBasicAuthPass())
+                {
+                    @Override
+                    public boolean matches(String type, URI uri, String realm)
+                    {
+                        if (!getType().equalsIgnoreCase(type))
+                            return false;
+
+                        if (!getRealm().equals(ANY_REALM) && !getRealm().equals(realm))
+                            return false;
+
+                        return true;
+                    }
+                };
+                AuthenticationStore store = httpClient.getAuthenticationStore();
+                store.clearAuthentications();
+                store.addAuthentication(auth);
+            }
         }
 
         httpClient.setMaxConnectionsPerDestination(config.getMaxConnectionsPerServer());

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -194,7 +194,7 @@ public class JettyHttpClient
             transport = new HttpClientTransportOverHTTP(CLIENT_TRANSPORT_SELECTORS);
         }
 
-        if (authenticationEnabled && config.getBasicAuthUser() == null && config.getBasicAuthPass() == null) {
+        if (authenticationEnabled && (config.getBasicAuthUser() == null || config.getBasicAuthPass() == null)) {
             requireNonNull(kerberosConfig.getConfig(), "kerberos config path is null");
             requireNonNull(config.getKerberosRemoteServiceName(), "kerberos remote service name is null");
             httpClient = new SpnegoHttpClient(kerberosConfig, config, transport, sslContextFactory);

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
@@ -56,7 +56,10 @@ public class TestHttpClientConfig
                 .setTrustStorePassword(System.getProperty(JAVAX_NET_SSL_TRUST_STORE_PASSWORD))
                 .setAuthenticationEnabled(false)
                 .setKerberosRemoteServiceName(null)
-                .setKerberosPrincipal(null));
+                .setKerberosPrincipal(null)
+                .setBasicAuthUser(null)
+                .setBasicAuthPass(null)
+                .setHostnameVerificationEnabled(true));
     }
 
     @Test
@@ -80,6 +83,9 @@ public class TestHttpClientConfig
                 .put("http-client.authentication.enabled", "true")
                 .put("http-client.authentication.krb5.remote-service-name", "airlift")
                 .put("http-client.authentication.krb5.principal", "airlift-client")
+                .put("http-client.hostname-verification.enabled", "false")
+                .put("http-client.authentication.basic-auth.user", "auth-user-foo")
+                .put("http-client.authentication.basic-auth.pass", "auth-pass-bar")
                 .build();
 
         HttpClientConfig expected = new HttpClientConfig()
@@ -99,7 +105,11 @@ public class TestHttpClientConfig
                 .setTrustStorePassword("trust-store-password")
                 .setAuthenticationEnabled(true)
                 .setKerberosRemoteServiceName("airlift")
-                .setKerberosPrincipal("airlift-client");
+                .setKerberosPrincipal("airlift-client")
+                .setBasicAuthUser("auth-user-foo")
+                .setBasicAuthPass("auth-pass-bar")
+                .setHostnameVerificationEnabled(false);
+        ;
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
`JettyHttpClient` is used to make requests between Airlift/Prestodb servers. When they communicating over the same port as the client, the Airlift servers expect some level of authentication.

One part that is a little awkward is that `JettyHttpClient` doesn't authenticate until it gets a 401 and it doesn't appear to retry properly. Rather than fixing the retry and having two round trips, I've opted to include any basic authentication by default that matches the URI and doesn't specify a realm. If the options are configured, the BasicAuthenticator this diff creates will be sent every request

```
http-client.authentication.basic-auth.user=set_user
http-client.authentication.basic-auth.pass=set_password
http-client.authentication.enabled=true
```